### PR TITLE
Remove .gitattributes in wrong location

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# specific for windows script files
-*.bat text eol=crlf


### PR DESCRIPTION
(Part of) fix for #34 and #35

The upgrade tool expects all diff changes to be under `RnDiffApp/` otherwise we get the error message:

`git apply -p2 patch.diff` -> `error: git diff header lacks filename information when removing 2 leading pathname components (line 6)`, meaning there's not "enough" ancestor paths to strip from `/.gitattributes`

~I guess this `.gitattributes` change should be applied to `RnDiffApp/.gitattributes`. I will do another pull request for that.~

The `.gitattributes` change should be included, if all the affected releases are regenerated from the new `app-base`