### PR TITLE
Make the required git config setting part of the new-release.sh script

### DIFF
--- a/README_MAINTAINERS.md
+++ b/README_MAINTAINERS.md
@@ -5,10 +5,6 @@ When a new release of `react-native` is out on [npm](https://www.npmjs.com/packa
 
 - Clone the repo, or pull the latest `master` if you have it already cloned.
 
-- Run `git config diff.nodiff.command true`.
-
-This is a setting that, in combination with the `.gitattributes` file, tells the scripts to not pay attention to some files that don't need to be in the diffs, like the root `.gitignore` of this repo (not the RnDiffApp project).
-
 - Execute the main script.
 ```sh
 ./new-release.sh <new-release>

--- a/new-release.sh
+++ b/new-release.sh
@@ -30,6 +30,8 @@ function guardExisting () {
 }
 
 function prepare () {
+    # This git config setting, in combination with the `.gitattributes` file, tells the scripts to not pay attention to some files that don't need to be in the diffs, like the root `.gitignore` of this repo (not the RnDiffApp project).
+    git config --local diff.nodiff.command true
     git pull
     yarn install
 }


### PR DESCRIPTION
The README_MAINTAINERS.md had a manual step to run before using `new-release.sh`, I've moved it to the prep step of the script instead.