### PR TITLE
Add new release workflow

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node
-      - uses: actions/setup-node@v2
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 
       - name: Checkout
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
 
       # Set path variables needed for caches
       - name: Set workflow variables
@@ -20,8 +20,8 @@ jobs:
         run: |
           echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
-        name: Yarn Cache
+      - name: Yarn Cache
+        uses: actions/cache@v2
         id: yarn-cache
         with:
           path: ${{ steps.workflow-variables.outputs.yarn-cache-dir }}

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -1,7 +1,8 @@
 name: Run new-release script
 
-on: repository_dispatch
-  types: [publish]
+on:
+  repository_dispatch:
+    types: [publish]
 
 jobs:
   update_diffs:

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -1,0 +1,18 @@
+name: Run new-release script
+
+on: repository_dispatch
+
+jobs:
+  generate_diffs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12.x"
+      - name: Install Dependencies
+        run: yarn
+      - name: Run new-release script
+        run: ./new-release.sh ${{ github.event.client_payload.version }}

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -6,13 +6,36 @@ jobs:
   generate_diffs:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
       - name: Setup Node
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
-      - name: Install Dependencies
-        run: yarn
+          node-version: 14
+
+      - name: Checkout
+      - uses: actions/checkout@v2
+
+      # Set path variables needed for caches
+      - name: Set workflow variables
+        id: workflow-variables
+        run: |
+          echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        name: Yarn Cache
+        id: yarn-cache
+        with:
+          path: ${{ steps.workflow-variables.outputs.yarn-cache-dir }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          restore-keys: ${{ runner.os }}-yarn-v1
+
+
+      - name: Yarn Install
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 10
+          retry_wait_seconds: 60
+          max_attempts: 3
+          command: yarn --no-audit --prefer-offline
+
       - name: Run new-release script
         run: ./new-release.sh ${{ github.event.client_payload.version }}

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -1,9 +1,10 @@
 name: Run new-release script
 
 on: repository_dispatch
+  types: [publish]
 
 jobs:
-  generate_diffs:
+  update_diffs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node


### PR DESCRIPTION
Trigger `new-release.sh` from a github workflow. We want this to be called from `react-native`'s publish job