### PR TITLE
chore(CI): fix up CI to be compliant with requirements (Node 16+)

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup asdf
-        uses: asdf-vm/actions/setup@v1
+        uses: asdf-vm/actions/setup@6844d09b13209e7d2ce3b63d2b089a2acef581ec
 
       - name: Cache asdf
         uses: actions/cache@v3
@@ -24,7 +24,7 @@ jobs:
             ${{ runner.os }}-asdf-
 
       - name: asdf install
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@6844d09b13209e7d2ce3b63d2b089a2acef581ec
 
       - name: yarn install
         run: yarn install

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: |
             ~/.asdf
-          key: ${{ runner.os }}-asdf-${{ hashFiles('**/.tool-versions') }}
+          key: ${{ runner.os }}-asdf-${{ '**/.tool-versions' }}
           restore-keys: |
             ${{ runner.os }}-asdf-
 


### PR DESCRIPTION
Basically someone pointed out at me that this action always fails: https://github.com/react-native-community/rn-diff-purge/actions/runs/4174403456

it seems that one of the main reasons is that CI is outdated, so this PR tries to take care of that (and there's also a complaint about  `hashFiles` so I tried to get rid of it).

I had to bump the asdf action version to commit hash because they haven't released a new version in a very long time, and we need this: https://github.com/asdf-vm/actions/commit/6844d09b13209e7d2ce3b63d2b089a2acef581ec

my question is actually what we use asdf for, and if we can remove that part entirely.