### PR TITLE
feat: use @react-native-community/cli instead of react-native

### DIFF
--- a/scripts/new-release.sh
+++ b/scripts/new-release.sh
@@ -56,7 +56,7 @@ function generateNewReleaseBranch () {
     git checkout -b "$branchName"
 
     # generate app and remove generated git repo
-    npx react-native@"${newRelease}" init "$AppName" --version "$newRelease" --skip-install
+    npx @react-native-community/cli@latest init "$AppName" --version "$newRelease" --skip-install
 
     # clean up before committing for diffing
     rm -rf "$AppName"/.git


### PR DESCRIPTION
Calling the CLI this way is the new guidance, as the old way will eventually stop working [1].

[1] https://github.com/facebook/react-native/commit/47a3f5200708fc0247d8b403dbe447af636b79cb