### PR TITLE
feat: ignore whitespaces from diffs

### DIFF
--- a/scripts/new-release.sh
+++ b/scripts/new-release.sh
@@ -113,8 +113,8 @@ function generateDiffs () {
     IFS=$'\n' GLOBIGNORE='*' command eval 'releases=($(cat "$ReleasesFile"))'
     for existingRelease in "${releases[@]}"
     do
-        git diff --binary -M15% origin/release/"$existingRelease"..origin/release/"$newRelease" > wt-diffs/diffs/"$existingRelease".."$newRelease".diff
-        git diff --binary -M15% origin/release/"$newRelease"..origin/release/"$existingRelease" > wt-diffs/diffs/"$newRelease".."$existingRelease".diff
+        git diff --binary -w -M15% origin/release/"$existingRelease"..origin/release/"$newRelease" > wt-diffs/diffs/"$existingRelease".."$newRelease".diff
+        git diff --binary -w -M15% origin/release/"$newRelease"..origin/release/"$existingRelease" > wt-diffs/diffs/"$newRelease".."$existingRelease".diff
     done
 
     cd wt-diffs


### PR DESCRIPTION
These are high noise. I don't see files that are materially affected in
the template by whitespaces (no .py, .yml, etc...).

Here's an example of some noise recently that would benefit from this
change: react-native-community/template#29, you can see the output [here](https://react-native-community.github.io/upgrade-helper/?from=0.74.2&to=0.75.0-rc.2#RnDiffApp-ios-RnDiffApp-PrivacyInfo.xcprivacy).
