### PR TITLE
Add configurable IgnorePaths, ignore README.md changes

### DIFF
--- a/scripts/new-release.sh
+++ b/scripts/new-release.sh
@@ -15,6 +15,7 @@ ReadmeTableBig=README_TABLE_BIG.md
 
 NumberOfReleases=12 # the number of releases on the table
 
+IgnorePaths=("README.md")
 
 function guardMissingArg () {
     if [ "$#" -ne 1 ]; then
@@ -120,7 +121,13 @@ function generateDiffs () {
             continue
         fi
 
-        git diff --binary -w -M15% origin/release/"$existingRelease"..origin/release/"$newRelease" > wt-diffs/diffs/"$existingRelease".."$newRelease".diff
+        ignoreArgs=()
+        for path in "${IgnorePaths[@]}"; do
+            ignoreArgs+=(":!$path")
+        done
+
+        git diff --binary -w -M15% origin/release/"$existingRelease"..origin/release/"$newRelease" \
+            -- . "${ignoreArgs[@]}" > wt-diffs/diffs/"$existingRelease".."$newRelease".diff
     done
 
     cd wt-diffs


### PR DESCRIPTION
## Summary

Follow up to https://github.com/react-native-community/template/pull/57#issuecomment-2355011136. README changes are not significant for users performing upgrades.

- Add configurable `IgnorePaths` variable to `new-release.sh`.
- Ignore `README.md` in diffs.

## Test Plan

**UNTESTED** — check CI?

I've locally validated the behaviour of `ignoreArgs` using `git diff ... ":!$path"`.