### PR TITLE
Align pnpx -> npx in release script

### DIFF
--- a/scripts/new-release.sh
+++ b/scripts/new-release.sh
@@ -145,7 +145,7 @@ function pushMaster () {
 
 function cleanUpYarnStuff () {
     rm -rf .yarn
-    pnpx node-jq 'del(.packageManager)' package.json | npx sponge package.json
+    npx node-jq 'del(.packageManager)' package.json | npx sponge package.json
 }
 
 function generateTable () {


### PR DESCRIPTION
We're currently experiencing some issues with this in the GHA, aligning it with the other code to unblock.